### PR TITLE
⚡ Bolt: Non-blocking analytics tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-04-02 - LRU Caching for normalizeMovieTitle
 **Learning:** Returning references to module-level cache entries without `Object.freeze` causes downstream mutation bugs, and missing max-size bounds will leak memory in the long-running script environment.
 **Action:** Always freeze return values from caches and set a `MAX_CACHE_SIZE` for unbounded maps in Node/Bun.
+
+## 2026-04-03 - Non-blocking analytics tracking
+**Learning:** Awaiting analytics API calls (like Umami) blocks the main execution flow and directly adds latency to the application's API responses.
+**Action:** Use fire-and-forget operations (`void trackAnalytics(...)`) for non-critical side effects like tracking to minimize response time.

--- a/src/server/api/routers/cinemaRouter.ts
+++ b/src/server/api/routers/cinemaRouter.ts
@@ -96,7 +96,7 @@ export const cinemaRouter = createTRPCRouter({
 
             const { showings: _showings, ...cinemaWithoutShowings } = cinema;
 
-            await trackCinemaView(cinema, ctx.ip);
+            void trackCinemaView(cinema, ctx.ip);
 
             return {
                 ...cinemaWithoutShowings,
@@ -194,7 +194,7 @@ export const cinemaRouter = createTRPCRouter({
                 },
             });
 
-            await trackCinemaView(cinemas, ctx.ip);
+            void trackCinemaView(cinemas, ctx.ip);
 
             return cinemas
                 .map((cinema) => {

--- a/src/server/api/routers/citiesRouter.ts
+++ b/src/server/api/routers/citiesRouter.ts
@@ -17,7 +17,7 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (city) {
-                await trackCityView(city, ctx.ip);
+                void trackCityView(city, ctx.ip);
             }
 
             return city;
@@ -78,7 +78,7 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (cities) {
-                await trackCityView(cities, ctx.ip)
+                void trackCityView(cities, ctx.ip)
             }
 
             return cities;
@@ -146,10 +146,8 @@ export const citiesRouter = createTRPCRouter({
             }
 
             if (city.cinemas) {
-                await Promise.all([
-                    trackCityView(city, ctx.ip),
-                    trackCinemaView(city.cinemas, ctx.ip)
-                ])
+                void trackCityView(city, ctx.ip);
+                void trackCinemaView(city.cinemas, ctx.ip);
             }
 
             // Transform to preserve the movies[] shape per cinema for the frontend
@@ -238,7 +236,7 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (city) {
-                await trackCityView(city, ctx.ip)
+                void trackCityView(city, ctx.ip)
             }
 
             return city;


### PR DESCRIPTION
💡 **What:** Replaced `await` with `void` for `trackCinemaView` and `trackCityView` analytics functions in the API routers (`src/server/api/routers/cinemaRouter.ts` and `src/server/api/routers/citiesRouter.ts`). Also removed the `await Promise.all()` wrapping from the analytics calls.

🎯 **Why:** Awaiting third-party telemetry calls blocks the main Node/Bun execution flow from immediately responding to the client, adding unnecessary latency to critical application routes. Using a "fire-and-forget" approach removes this bottleneck, improving perceived performance.

📊 **Impact:** Reduces latency in API route responses (e.g., getting nearby cinemas, looking up cities) by the amount of time it takes to resolve the Umami analytics API call.

🔬 **Measurement:** Can be verified by measuring TTFB (time to first byte) for the affected TRPC endpoints or by running API benchmarks against the endpoints with and without the awaited tracking calls.

Additionally, updated `.jules/bolt.md` with learnings regarding non-blocking analytics APIs in this application.

---
*PR created automatically by Jules for task [175903096739458358](https://jules.google.com/task/175903096739458358) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response times for cinema and city data endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->