### PR TITLE
⚡ Bolt: [performance improvement] Make Umami analytics tracking non-blocking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-04-02 - LRU Caching for normalizeMovieTitle
 **Learning:** Returning references to module-level cache entries without `Object.freeze` causes downstream mutation bugs, and missing max-size bounds will leak memory in the long-running script environment.
 **Action:** Always freeze return values from caches and set a `MAX_CACHE_SIZE` for unbounded maps in Node/Bun.
+
+## 2025-04-03 - [Non-Blocking Analytics Tracking]
+**Learning:** Analytics tracking calls to external services (like Umami) can add unnecessary latency to API responses if they are awaited.
+**Action:** Always use the `void` operator with a `.catch()` block for 'fire and forget' analytics operations (e.g. `trackCinemaView(...).catch(console.error)`) to ensure they do not block the main request flow, minimize API latency, and prevent UnhandledPromiseRejections.

--- a/src/server/api/routers/cinemaRouter.ts
+++ b/src/server/api/routers/cinemaRouter.ts
@@ -96,7 +96,8 @@ export const cinemaRouter = createTRPCRouter({
 
             const { showings: _showings, ...cinemaWithoutShowings } = cinema;
 
-            await trackCinemaView(cinema, ctx.ip);
+            // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+            void trackCinemaView(cinema, ctx.ip).catch(console.error);
 
             return {
                 ...cinemaWithoutShowings,
@@ -194,7 +195,8 @@ export const cinemaRouter = createTRPCRouter({
                 },
             });
 
-            await trackCinemaView(cinemas, ctx.ip);
+            // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+            void trackCinemaView(cinemas, ctx.ip).catch(console.error);
 
             return cinemas
                 .map((cinema) => {

--- a/src/server/api/routers/citiesRouter.ts
+++ b/src/server/api/routers/citiesRouter.ts
@@ -17,7 +17,8 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (city) {
-                await trackCityView(city, ctx.ip);
+                // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+                void trackCityView(city, ctx.ip).catch(console.error);
             }
 
             return city;
@@ -78,7 +79,8 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (cities) {
-                await trackCityView(cities, ctx.ip)
+                // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+                void trackCityView(cities, ctx.ip).catch(console.error);
             }
 
             return cities;
@@ -146,10 +148,11 @@ export const citiesRouter = createTRPCRouter({
             }
 
             if (city.cinemas) {
-                await Promise.all([
+                // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+                void Promise.all([
                     trackCityView(city, ctx.ip),
                     trackCinemaView(city.cinemas, ctx.ip)
-                ])
+                ]).catch(console.error);
             }
 
             // Transform to preserve the movies[] shape per cinema for the frontend
@@ -238,7 +241,8 @@ export const citiesRouter = createTRPCRouter({
             });
 
             if (city) {
-                await trackCityView(city, ctx.ip)
+                // ⚡ Bolt: Fire-and-forget analytics tracking to prevent blocking the API response
+                void trackCityView(city, ctx.ip).catch(console.error);
             }
 
             return city;


### PR DESCRIPTION
💡 **What:** 
Replaced `await trackCinemaView(...)` and `await trackCityView(...)` calls in the tRPC API routers (`cinemaRouter.ts` and `citiesRouter.ts`) with `void trackCinemaView(...).catch(console.error)` to make them fire-and-forget.

🎯 **Why:** 
Previously, the backend awaited the response from the external Umami analytics service before returning the requested cinema/city data back to the user. This added unnecessary network round-trip latency to the end-user. External analytics calls do not affect the integrity of the returned payload, so waiting for them is suboptimal.

📊 **Impact:** 
Eliminates the latency added by Umami network requests (typically 50-200ms depending on the environment) from the critical path of the main API response.

🔬 **Measurement:** 
Review the API response times for `getCinemaBySlug`, `getNearbyCinemas`, `getCityBySlug`, and `getCityMoviesAndShowingsBySlug` under high load; they will now resolve independently of analytics service performance.

---
*PR created automatically by Jules for task [14438150800848194661](https://jules.google.com/task/14438150800848194661) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guideline for non-blocking analytics tracking practices.

* **Refactor**
  * Optimized analytics operations across cinema and city endpoints to execute asynchronously without blocking API responses, improving response time and preventing request failures from analytics errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->