### PR TITLE
🎨 Palette: Add screen reader label for showing times

### DIFF
--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -17,14 +17,17 @@ export const ShowingTimePill = ({
   movieName,
   cinemaSlug,
 }: ShowingTimePillProps) => {
+  const formattedTime = formatShowingTime(showing.dateTime);
+
   return (
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
       className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      aria-label={`Vorstellung um ${formattedTime} Uhr buchen`}
     >
-      <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-      <span>{formatShowingTime(showing.dateTime)}</span>
+      <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" aria-hidden="true" />
+      <span>{formattedTime}</span>
       <ShowingTags
         showingId={showing.id}
         titleTags={showing.tags}


### PR DESCRIPTION
💡 **What**: Added an explicit `aria-label` to the `ShowingTimePill` links and hid the decorative clock icon from screen readers.
🎯 **Why**: When a user navigates the available showings via screen reader or keyboard, previously they would only hear something like "18:00, Link", missing the crucial context that clicking this will initiate a booking for that specific time.
♿ **Accessibility**: Enhanced screen reader UX by providing a full, descriptive sentence (e.g. "Vorstellung um 18:00 Uhr buchen") and omitting the decorative `<Clock3>` icon via `aria-hidden="true"` to avoid redundant announcements.

---
*PR created automatically by Jules for task [17245029598577159284](https://jules.google.com/task/17245029598577159284) started by @niklasarnitz*