### PR TITLE
⚡ Bolt: Combine filter and map to avoid intermediate array allocations

### DIFF
--- a/src/helpers/catalogUpdater/resolveAndPersistCatalog.ts
+++ b/src/helpers/catalogUpdater/resolveAndPersistCatalog.ts
@@ -55,9 +55,14 @@ export const resolveAndPersistCatalog = async (
     });
 
     // Build lookup maps for database movies
-    const dbMovieByTmdbId = new Map(
-        dbMovies.filter((m) => m.tmdbMovieId).map((m) => [m.tmdbMovieId!, m])
-    );
+    // ⚡ Bolt: Using a for...of loop avoids intermediate array allocations from .filter().map()
+    const dbMovieByTmdbId = new Map<number, typeof dbMovies[0]>();
+    for (const m of dbMovies) {
+        if (m.tmdbMovieId) {
+            dbMovieByTmdbId.set(m.tmdbMovieId, m);
+        }
+    }
+
     const dbMoviesByNormalizedTitle = new Map<string, typeof dbMovies>();
     for (const movie of dbMovies) {
         const key = normalizeForComparison(movie.normalizedTitle);


### PR DESCRIPTION
**💡 What:** Refactored `resolveAndPersistCatalog` to replace a `.filter().map()` chain with a single `for...of` loop when building the `dbMovieByTmdbId` lookup map.
**🎯 Why:** The original implementation allocated two intermediate arrays (`.filter` and then `.map`) before inserting the elements into the `Map`. For potentially large datasets like `dbMovies`, this increases garbage collection pressure and unnecessarily consumes memory.
**📊 Impact:** Avoids creating two intermediate arrays, slightly reducing execution time and lowering the memory footprint inside a critical backend loop. O(N) operations remain, but overhead is drastically reduced.
**🔬 Measurement:** Execution will slightly drop in garbage-collection cycles and memory profiling when processing thousands of existing movies compared to before. Tests pass, verifying no behavior was broken.

---
*PR created automatically by Jules for task [2926865778282472913](https://jules.google.com/task/2926865778282472913) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data processing efficiency with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->