### PR TITLE
🎨 Palette: Add keyboard focus indicators & ARIA to interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-04 - Keyboard Accessibility on Interactive Elements
+**Learning:** In a project using Tailwind CSS, global outline resets often strip default focus indicators from links and buttons. Custom interactive elements like "time pills" (links styled as pills) or icon-only buttons (like a search reset "X") easily become invisible to keyboard navigation.
+**Action:** Always verify keyboard focus state for custom-styled interactive components. Apply `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1` to ensure visible focus indicators and provide descriptive `aria-label`s for dynamic elements (e.g., ticket times).

--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -28,7 +28,7 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                     aria-label="Suche zurücksetzen"
                 >
                     <X className="h-3.5 w-3.5" />

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -17,14 +17,17 @@ export const ShowingTimePill = ({
   movieName,
   cinemaSlug,
 }: ShowingTimePillProps) => {
+  const formattedTime = formatShowingTime(showing.dateTime);
+
   return (
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      aria-label={`Tickets für ${movieName} um ${formattedTime} Uhr`}
     >
       <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-      <span>{formatShowingTime(showing.dateTime)}</span>
+      <span>{formattedTime}</span>
       <ShowingTags
         showingId={showing.id}
         titleTags={showing.tags}


### PR DESCRIPTION
💡 **What:** Added missing `focus-visible` ring utility classes to interactive components (`ShowingTimePill` and the clear search button in `SearchTextField`). Also added a descriptive `aria-label` to the `ShowingTimePill`.

🎯 **Why:** Tailwind CSS's base styles often remove the browser's default focus ring from `<a>` and `<button>` elements. Without explicitly adding `focus-visible` styles, users relying on keyboard navigation (like hitting the Tab key) have no way of knowing which element is currently focused. This was true for the time pill links and the clear search icon. Furthermore, the `ShowingTimePill` link only had the time visible; screen readers would just announce "15:30", which lacks context. The added `aria-label` provides the full movie name and time context.

♿ **Accessibility:**
- Added visible focus indicators for keyboard users (`focus-visible:ring-2`)
- Improved screen reader experience by adding contextual `aria-label`s to time pills (e.g., "Tickets für Dune: Part Two um 15:30 Uhr").

Log added to `.Jules/palette.md` noting the importance of manually defining focus styles for interactive elements in Tailwind projects.

---
*PR created automatically by Jules for task [9000540474392378489](https://jules.google.com/task/9000540474392378489) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Improved keyboard focus visibility** on interactive elements with enhanced ring styling for clearer focus indicators during keyboard navigation.
* **Enhanced visual feedback** for keyboard users navigating through buttons and links.
* **Added descriptive labels** to interactive components for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->