### PR TITLE
🎨 Palette: Add focus-visible states to interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-05 - Missing Focus States on Custom Interactive Elements
+**Learning:** Tailwind global outline resets often strip default browser focus indicators. This causes custom interactive elements like custom pill links (`<Link>`), icon-only buttons, and native range inputs to become completely inaccessible to keyboard users because they lack visual feedback when focused.
+**Action:** Always verify and apply explicit focus styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`) to custom interactive elements for keyboard accessibility.

--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -116,7 +116,7 @@ export function CommandSearch() {
             <button
                 type="button"
                 onClick={() => setOpen(true)}
-                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             >
                 <Search className="h-3.5 w-3.5" />
                 <span className="flex-1 text-left">Suchen…</span>

--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -186,7 +186,7 @@ export const NearbyCinemasSection = () => {
                             disabled={isLocating}
                             title="Standort erneut abfragen"
                             aria-label="Standort erneut abfragen"
-                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2"
+                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                         >
                             {isLocating ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin sm:h-4 sm:w-4" />
@@ -249,7 +249,7 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
-                                className="h-3 w-20 accent-primary sm:w-28"
+                                className="h-3 w-20 accent-primary sm:w-28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
                             />
                         </span>
                     </div>

--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -28,7 +28,7 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                     aria-label="Suche zurücksetzen"
                 >
                     <X className="h-3.5 w-3.5" />

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -21,7 +21,7 @@ export const ShowingTimePill = ({
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
     >
       <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
       <span>{formatShowingTime(showing.dateTime)}</span>


### PR DESCRIPTION
### 💡 What
Added explicit `focus-visible` classes to custom interactive elements (buttons, inputs, links) to restore their focus indicators.
Logged a critical UX learning about Tailwind outline resets and their effect on keyboard accessibility to `.Jules/palette.md`.

### 🎯 Why
Tailwind global outline resets often strip default browser focus indicators, making custom interactive elements invisible to keyboard users when focused. Explicit focus styling ensures that users navigating via keyboard always have clear visual feedback on which element is currently active.

### ♿ Accessibility
- Fixed missing focus states on `ShowingTimePill` pill links.
- Fixed missing focus states on the `NearbyCinemasSection` location request button and radius slider.
- Fixed missing focus states on the `SearchTextField` clear button.
- Fixed missing focus states on the `CommandSearch` trigger button.

---
*PR created automatically by Jules for task [6517345807748953267](https://jules.google.com/task/6517345807748953267) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved keyboard accessibility with visible focus indicators on buttons, form controls, and links throughout the app for better keyboard navigation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->