### PR TITLE
🎨 Palette: Add focus indicators to utility icon buttons

### DIFF
--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -186,7 +186,7 @@ export const NearbyCinemasSection = () => {
                             disabled={isLocating}
                             title="Standort erneut abfragen"
                             aria-label="Standort erneut abfragen"
-                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2"
+                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                         >
                             {isLocating ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin sm:h-4 sm:w-4" />

--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -28,7 +28,7 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                     aria-label="Suche zurücksetzen"
                 >
                     <X className="h-3.5 w-3.5" />


### PR DESCRIPTION
💡 What: Added explicit keyboard focus indicator styling (`focus-visible:ring-2`) to two custom icon-only utility buttons: the clear search input button (`SearchTextField.tsx`) and the refresh location button (`NearbyCinemasSection.tsx`).

🎯 Why: In this project, the global Tailwind preflight resets default outline styling. While some buttons use hover states correctly, they lacked keyboard-navigable focus states, rendering them nearly invisible for screen readers or tab-only users trying to interact with them. 

📸 Before/After: Visual changes apply only when interacting via the keyboard (e.g., Tabbing). Upon focus, these buttons will now display a high-contrast ring outline.

♿ Accessibility: Ensures WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) is met for these interactive components.

---
*PR created automatically by Jules for task [10440525596681959846](https://jules.google.com/task/10440525596681959846) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual focus indicators on buttons to enhance keyboard navigation and accessibility for users navigating without a mouse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->