### PR TITLE
🎨 Palette: Keyboard Accessibility Improvements for Slider and Pills

### DIFF
--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -249,7 +249,12 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
-                                className="h-3 w-20 accent-primary sm:w-28"
+                                onKeyUp={(event) => {
+                                    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) {
+                                        handleRadiusRelease();
+                                    }
+                                }}
+                                className="h-3 w-20 accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:w-28"
                             />
                         </span>
                     </div>

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -21,7 +21,8 @@ export const ShowingTimePill = ({
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      aria-label={`Vorstellung für ${movieName} um ${formatShowingTime(showing.dateTime)}`}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
     >
       <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
       <span>{formatShowingTime(showing.dateTime)}</span>


### PR DESCRIPTION
💡 **What:** Added keyboard support (`onKeyUp` handler) to the radius slider so arrow keys correctly apply changes. Added proper `focus-visible` ring styles to both the radius slider and the time showing pills. Added an `aria-label` to the time showing pills.

🎯 **Why:** Previously, the radius slider would visually change when using arrow keys, but the updated radius value was never applied because the component only listened to `onMouseUp` and `onTouchEnd`. Adding `onKeyUp` fixes this for keyboard users. Furthermore, interactive elements lacked explicit focus indicators, making it difficult for keyboard users to track their position on the page. The `aria-label` on time pills ensures screen readers announce context-aware information.

♿ **Accessibility:**
- Added `focus-visible` styles to range slider.
- Added `focus-visible` styles to `ShowingTimePill` links.
- Added an `aria-label` (localized in German) to the `ShowingTimePill` so screen readers hear "Vorstellung für [Movie] um [Time]" instead of just "19:00".
- Added `onKeyUp` handler to the `NearbyCinemasSection` radius slider so keyboard input saves the new radius correctly.

---
*PR created automatically by Jules for task [12652718790366149956](https://jules.google.com/task/12652718790366149956) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Arrow key support now works when adjusting the radius slider
* Improved keyboard focus visibility for better keyboard navigation
* Enhanced screen reader descriptions for movie showing times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->