### PR TITLE
🎨 Palette: Make range slider keyboard accessible

### DIFF
--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -249,6 +249,7 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
+                                onKeyUp={handleRadiusRelease}
                                 className="h-3 w-20 accent-primary sm:w-28"
                             />
                         </span>


### PR DESCRIPTION
💡 **What**: Added an `onKeyUp` event handler to the range slider in `NearbyCinemasSection.tsx`.

🎯 **Why**: Previously, the range slider committed its value (triggering a location update and saving to cookies) only on `onMouseUp` and `onTouchEnd` events. This meant that users adjusting the slider using the keyboard (arrow keys) would not trigger the update. By adding `onKeyUp`, keyboard users can now successfully commit their changes.

♿ **Accessibility**: Improved keyboard accessibility and feature parity for users who rely on keyboard navigation.

---
*PR created automatically by Jules for task [13444721368129300564](https://jules.google.com/task/13444721368129300564) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard accessibility for the radius filter by enabling proper keyboard interaction and deferred updates when using keyboard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->