### PR TITLE
🎨 Palette: Keyboard Accessibility for Radius Slider

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-04-02 - Add keyboard focus and screen reader states to custom toggle buttons
 **Learning:** Found multiple instances where custom toggle buttons (like the quick date toggles and cinema filter pills) lacked explicit focus states for keyboard navigation. While they used background colors to indicate active state visually, screen readers and keyboard-only users lacked proper context and interaction cues.
 **Action:** Always verify that custom interactive elements (`<button>`) without an explicit underlying form library or standard UI component have robust focus styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`) and explicitly convey their active toggle state using the `aria-pressed` attribute for screen readers.
+
+## 2025-04-09 - Range Slider Keyboard Accessibility
+**Learning:** Range sliders (`<input type="range">`) often rely on `onMouseUp` or `onTouchEnd` to trigger data fetches (like radius search). However, keyboard users navigating with arrow keys cannot trigger these events, leaving them unable to commit the selection. Also, standard outline resets often hide focus rings on custom sliders.
+**Action:** When implementing range inputs that commit state on interaction end, ensure an `onKeyUp` handler is also implemented to catch keyboard adjustments. Always explicitly apply `focus-visible` styling to custom range inputs.

--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -249,7 +249,8 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
-                                className="h-3 w-20 accent-primary sm:w-28"
+                                onKeyUp={handleRadiusRelease}
+                                className="h-3 w-20 accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:w-28"
                             />
                         </span>
                     </div>


### PR DESCRIPTION
**💡 What:** 
Added an `onKeyUp` event handler (`onKeyUp={handleRadiusRelease}`) to the radius slider (`<input type="range">`) in the `NearbyCinemasSection` component. Additionally, explicitly added focus ring styling classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`).

**🎯 Why:**
The radius slider previously relied exclusively on `onMouseUp` and `onTouchEnd` events to commit state changes and trigger the data refetch. When a user navigates and modifies the slider using the keyboard (e.g., arrow keys), the value visually changes, but the required commit event is never fired because no click or touch is released. Adding `onKeyUp` captures the end of the keyboard interaction.

**♿ Accessibility:**
- Keyboard users can now successfully adjust the radius and trigger updates using their arrow keys.
- Added explicit `focus-visible` classes so the slider has a clear, visible focus ring when navigated to via keyboard, since default global outline resets often strip native focus indicators from range sliders.

---
*PR created automatically by Jules for task [5801181826165401964](https://jules.google.com/task/5801181826165401964) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessibility for range input controls by adding keyboard release event handling and enhancing focus visibility with visible focus ring indicators to better support keyboard-based navigation and interaction.

* **Documentation**
  * Added accessibility documentation detailing best practices for implementing keyboard support on range input components, including recommendations for focus styling and keyboard event handler patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->