### PR TITLE
🎨 Palette: Improve keyboard accessibility for location controls

### DIFF
--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -186,7 +186,7 @@ export const NearbyCinemasSection = () => {
                             disabled={isLocating}
                             title="Standort erneut abfragen"
                             aria-label="Standort erneut abfragen"
-                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2"
+                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:p-2"
                         >
                             {isLocating ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin sm:h-4 sm:w-4" />
@@ -249,7 +249,8 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
-                                className="h-3 w-20 accent-primary sm:w-28"
+                                onKeyUp={handleRadiusRelease}
+                                className="h-3 w-20 accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:w-28"
                             />
                         </span>
                     </div>


### PR DESCRIPTION
### 💡 What
Added missing keyboard accessibility features to the Nearby Cinemas section controls. Specifically, the radius range slider now updates when releasing an arrow key (via `onKeyUp`), and both the slider and the location refresh button now have explicit focus-visible rings.

### 🎯 Why
Users navigating via keyboard (tabbing) previously could not easily determine which control they had focused on due to global resets stripping the default outline. Furthermore, adjusting the `<input type="range">` with the keyboard arrows changed its internal value but failed to trigger the actual distance update because the handler was only bound to `onMouseUp` and `onTouchEnd`.

### ♿ Accessibility
- Ensured keyboard navigation is visually trackable for interactive controls (`focus-visible:ring-2`).
- Fixed a functional gap where keyboard-only users were excluded from adjusting the search radius.

---
*PR created automatically by Jules for task [5768211817046718454](https://jules.google.com/task/5768211817046718454) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility & Usability**
  * Improved keyboard navigation and focus visibility for nearby cinemas location search and radius adjustment controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->