### PR TITLE
🎨 Palette: Improve keyboard focus and add tooltips to interactive elements

### DIFF
--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -116,7 +116,9 @@ export function CommandSearch() {
             <button
                 type="button"
                 onClick={() => setOpen(true)}
-                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                title="Suche öffnen"
+                aria-label="Suche öffnen"
             >
                 <Search className="h-3.5 w-3.5" />
                 <span className="flex-1 text-left">Suchen…</span>

--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -30,6 +30,7 @@ export const SearchTextField = () => {
                     }}
                     className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
                     aria-label="Suche zurücksetzen"
+                    title="Suche zurücksetzen"
                 >
                     <X className="h-3.5 w-3.5" />
                 </button>

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -21,7 +21,8 @@ export const ShowingTimePill = ({
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      title="Tickets buchen"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
     >
       <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
       <span>{formatShowingTime(showing.dateTime)}</span>


### PR DESCRIPTION
💡 **What:** Added missing `title` attributes for tooltips on icon-only buttons (search trigger, search clear) and showing time pills. Also explicitly added standard focus-visible rings for keyboard navigation to the CommandSearch trigger button and ShowingTimePills links.
🎯 **Why:** To improve accessibility for screen readers and keyboard users, and provide visual tooltips to mouse users for icon-only actions where the purpose might not be immediately obvious.
📸 **Before/After:** Not applicable (visual changes are only tooltips and keyboard focus rings).
♿ **Accessibility:** Added focus states (`focus-visible:ring-2`) and explicit descriptive `title` attributes to improve discoverability and keyboard navigation.

---
*PR created automatically by Jules for task [17533872106624931671](https://jules.google.com/task/17533872106624931671) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation with visible focus indicators on search button and ticket booking controls.
  * Added descriptive tooltips and enhanced accessible labels to search fields and reset functionality for better compatibility with screen readers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->