### PR TITLE
🎨 Palette: Improve accessibility and keyboard navigation in search and movie pills

### DIFF
--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -20,6 +20,7 @@ export const SearchTextField = () => {
                     void setSearchQuery(event.target.value);
                 }}
                 placeholder="Stadt oder Kino suchen"
+                aria-label="Stadt oder Kino suchen"
                 className="h-10 flex-1 rounded-xl border-sidebar-border bg-sidebar px-9 text-sm shadow-none focus-visible:ring-2"
             />
             {Boolean(searchQuery) && (
@@ -28,8 +29,9 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                     aria-label="Suche zurücksetzen"
+                    title="Suche zurücksetzen"
                 >
                     <X className="h-3.5 w-3.5" />
                 </button>

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -21,7 +21,8 @@ export const ShowingTimePill = ({
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      title={`Vorstellung buchen: ${movieName} um ${formatShowingTime(showing.dateTime)} Uhr`}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
     >
       <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
       <span>{formatShowingTime(showing.dateTime)}</span>


### PR DESCRIPTION
### 💡 What
- Added an `aria-label` to the global command search `<Input>`.
- Added clear `title` attributes (tooltips) and explicit `focus-visible` states to the search input's clear button and the `ShowingTimePill` links.

### 🎯 Why
- These small but critical interactive elements lacked sufficient context for screen readers and keyboard users.
- The `ShowingTimePill` previously only displayed the time, but now hover states and screen readers will more clearly convey the action context (e.g., 'Vorstellung buchen: [Movie] um [Time] Uhr').
- The default focus outline resets in the project often make keyboard tabbing nearly invisible on these elements. The explicit `focus-visible` styles restore the necessary focus rings.

### 📸 Before/After
Screenshots were captured during UI verification and have been attached alongside this PR to demonstrate the command menu improvements and active visual states.

### ♿ Accessibility
- Restores keyboard focus visibility using standard Tailwind classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`).
- Provides explicit label context (`aria-label`, `title`) for an icon-only button and standardizes context on minimalist UI components.

---
*PR created automatically by Jules for task [7687646530926506189](https://jules.google.com/task/7687646530926506189) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation focus visibility in search and movie listing components
  * Enhanced accessibility with descriptive labels and helpful tooltips for interactive elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->