### PR TITLE
🎨 Palette: Improve keyboard focus and screen reader context for showing pills and search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-04-02 - Add keyboard focus and screen reader states to custom toggle buttons
 **Learning:** Found multiple instances where custom toggle buttons (like the quick date toggles and cinema filter pills) lacked explicit focus states for keyboard navigation. While they used background colors to indicate active state visually, screen readers and keyboard-only users lacked proper context and interaction cues.
 **Action:** Always verify that custom interactive elements (`<button>`) without an explicit underlying form library or standard UI component have robust focus styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`) and explicitly convey their active toggle state using the `aria-pressed` attribute for screen readers.
+
+## 2025-04-14 - Screen reader context for isolated visual elements like Showing Pills
+**Learning:** Time pills (`<ShowingTimePill>`) displaying only a formatted time string (e.g., "14:30") lacked surrounding context. A screen reader reading simply "14:30" is confusing without knowing what happens at 14:30.
+**Action:** When creating visual "pill" buttons or links that rely on their visual context (like being nested under a movie name), always wrap the bare text with visually hidden `sr-only` context (e.g., `<span className="sr-only">Tickets für {movieName} um </span>14:30<span className="sr-only"> Uhr buchen</span>`) to make the resulting interaction clear to assistive technologies without overriding other nested children (like `ShowingTags`).

--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -116,7 +116,9 @@ export function CommandSearch() {
             <button
                 type="button"
                 onClick={() => setOpen(true)}
-                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                aria-label="Stadt oder Kino suchen"
+                title="Stadt oder Kino suchen (⌘K)"
+                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             >
                 <Search className="h-3.5 w-3.5" />
                 <span className="flex-1 text-left">Suchen…</span>

--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -20,6 +20,7 @@ export const SearchTextField = () => {
                     void setSearchQuery(event.target.value);
                 }}
                 placeholder="Stadt oder Kino suchen"
+                aria-label="Stadt oder Kino suchen"
                 className="h-10 flex-1 rounded-xl border-sidebar-border bg-sidebar px-9 text-sm shadow-none focus-visible:ring-2"
             />
             {Boolean(searchQuery) && (
@@ -28,8 +29,9 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    title="Suche zurücksetzen"
                     aria-label="Suche zurücksetzen"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                 >
                     <X className="h-3.5 w-3.5" />
                 </button>

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -21,10 +21,15 @@ export const ShowingTimePill = ({
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      title={`Tickets für ${movieName} um ${formatShowingTime(showing.dateTime)} Uhr buchen`}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
     >
-      <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-      <span>{formatShowingTime(showing.dateTime)}</span>
+      <Clock3 aria-hidden="true" className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+      <span>
+        <span className="sr-only">Tickets für {movieName} um </span>
+        {formatShowingTime(showing.dateTime)}
+        <span className="sr-only"> Uhr buchen</span>
+      </span>
       <ShowingTags
         showingId={showing.id}
         titleTags={showing.tags}


### PR DESCRIPTION
💡 **What:** Added keyboard focus styling (`focus-visible`), explicit `aria-label`s, `title` tooltips, and visually hidden context strings (`sr-only`) to interactive elements.
🎯 **Why:** To make the application more accessible for keyboard users, screen reader users, and mouse users who benefit from contextual tooltips. Without these changes, interactive elements like time pills were difficult to navigate with a keyboard and lacked descriptive context for screen readers.
♿ **Accessibility:**
- Custom interactive elements now have visible focus rings (`focus-visible:ring-ring`).
- Decorative icons are hidden from screen readers (`aria-hidden="true"`).
- Time pills now announce as full actions ("Tickets für {movieName} um {time} Uhr buchen") instead of just isolated times.
- Search inputs and buttons have robust `aria-label`s.

---
*PR created automatically by Jules for task [2107899181856831822](https://jules.google.com/task/2107899181856831822) started by @niklasarnitz*