### PR TITLE
🎨 Palette: Improve keyboard accessibility for location radius slider

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Fix Keyboard Accessibility for Radius Slider**: Add `onKeyUp` handler to the `<input type="range">` in `src/components/NearbyCinemasSection.tsx` so that keyboard users (who use arrow keys) can trigger the `handleRadiusRelease` commit action.
+2. **Add Focus Styles for Range Input & Action Buttons**: Add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1` to the radius slider input and the "Standort erneut abfragen" icon button to ensure clear keyboard focus indicators.
+3. **Verify UI/Accessibility Improvements**: Run formatting/linting scripts (`bun lint`) to ensure the changes are valid, and manually verify the diff.
+4. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+5. **Create the Pull Request**: Submit the change with "🎨 Palette: [UX improvement]" title and specific UX problem details in the description.

--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -186,7 +186,7 @@ export const NearbyCinemasSection = () => {
                             disabled={isLocating}
                             title="Standort erneut abfragen"
                             aria-label="Standort erneut abfragen"
-                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed sm:p-2"
+                            className="shrink-0 inline-flex items-center justify-center rounded-full bg-primary p-1.5 text-primary-foreground transition hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:p-2"
                         >
                             {isLocating ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin sm:h-4 sm:w-4" />
@@ -249,7 +249,8 @@ export const NearbyCinemasSection = () => {
                                 onChange={(event) => setRadiusKm(Number(event.target.value))}
                                 onMouseUp={handleRadiusRelease}
                                 onTouchEnd={handleRadiusRelease}
-                                className="h-3 w-20 accent-primary sm:w-28"
+                                onKeyUp={handleRadiusRelease}
+                                className="h-3 w-20 accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:w-28"
                             />
                         </span>
                     </div>


### PR DESCRIPTION
💡 **What**: Added keyboard support for releasing the location radius slider (via arrow keys) and added visible focus rings for better tab navigation on the slider and location request button in `NearbyCinemasSection.tsx`.

🎯 **Why**: Previously, the range input only updated the user's location radius on mouse up (`onMouseUp`) or touch end (`onTouchEnd`), making it impossible for keyboard users to easily submit the changed radius value without a mouse. In addition, the interactive elements lacked clear focus rings, making tab navigation less obvious.

📸 **Before/After**: Verified via Playwright screenshots that the `<input type="range">` and the location retry icon button now have distinct focus rings when tabbed to.

♿ **Accessibility**: Enhanced keyboard navigation and focus-visibility indicators.

---
*PR created automatically by Jules for task [7165844136143170035](https://jules.google.com/task/7165844136143170035) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled keyboard control for adjusting the cinema search radius

* **Style**
  * Improved visual focus indicators on location and radius controls for enhanced keyboard navigation accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->