### PR TITLE
🎨 Palette: Improve accessibility and UX of ShowingTimePill

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-04-02 - Add keyboard focus and screen reader states to custom toggle buttons
 **Learning:** Found multiple instances where custom toggle buttons (like the quick date toggles and cinema filter pills) lacked explicit focus states for keyboard navigation. While they used background colors to indicate active state visually, screen readers and keyboard-only users lacked proper context and interaction cues.
 **Action:** Always verify that custom interactive elements (`<button>`) without an explicit underlying form library or standard UI component have robust focus styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`) and explicitly convey their active toggle state using the `aria-pressed` attribute for screen readers.
+
+## 2025-04-16 - Add robust aria-labels and decorative icons in `ShowingTimePill`
+**Learning:** Found that time pill links only announced the raw clock time to screen readers (e.g., "14:30") and had no focus styling when navigating via keyboard. Additionally, the decorative `Clock3` icon lacked `aria-hidden="true"`, leading to potential double or messy announcements.
+**Action:** When creating semantic links that rely on visual context (like a time pill underneath a movie title), ensure you build a comprehensive `aria-label` (e.g., "Tickets für [Movie] um [Time] Uhr buchen") and hide decorative icons using `aria-hidden="true"`. Also always verify focus states as global resets can strip them.

--- a/src/components/movie-listing/ShowingTimePill.tsx
+++ b/src/components/movie-listing/ShowingTimePill.tsx
@@ -17,14 +17,19 @@ export const ShowingTimePill = ({
   movieName,
   cinemaSlug,
 }: ShowingTimePillProps) => {
+  const formattedTime = formatShowingTime(showing.dateTime);
+  const ariaLabelText = `Tickets für ${movieName} um ${formattedTime} Uhr buchen`;
+
   return (
     <Link
       key={`${movieName}-${cinemaSlug}-${showing.id}-${showing.dateTime.toISOString()}`}
       href={showing.bookingUrl ?? "#"}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/80 px-2.5 py-1 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      aria-label={ariaLabelText}
+      title={ariaLabelText}
     >
-      <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-      <span>{formatShowingTime(showing.dateTime)}</span>
+      <Clock3 className="h-3 w-3 sm:h-3.5 sm:w-3.5" aria-hidden="true" />
+      <span>{formattedTime}</span>
       <ShowingTags
         showingId={showing.id}
         titleTags={showing.tags}


### PR DESCRIPTION
### 💡 What
Added comprehensive accessibility features and focus styling to the `ShowingTimePill` component. 
- The time pill link now features a descriptive `aria-label` and `title` (e.g., "Tickets für [Movie] um [Time] Uhr buchen") instead of just reading out a raw time.
- The decorative `Clock3` icon now has `aria-hidden="true"`.
- Keyboard navigation is improved with explicit `focus-visible` utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1`).

### 🎯 Why
Screen reader users navigating through movie listings would previously just hear a raw time (e.g. "14:30") without context of what the link actually does. Additionally, because global resets often strip default browser focus rings, keyboard-only users would lose track of their position when tabbing through the numerous time pills on the movie listing page. This change ensures the interaction is both semantically clear and visually robust.

### ♿ Accessibility
- Enhanced screen reader context via `aria-label`.
- Reduced noise by hiding decorative icons (`aria-hidden="true"`).
- Restored visual focus indicators for keyboard users (`focus-visible`).
- Added native tooltip (`title`) for pointer-device users.

---
*PR created automatically by Jules for task [12708479872773662946](https://jules.google.com/task/12708479872773662946) started by @niklasarnitz*