### PR TITLE
🎨 Palette: Improve SearchTextField accessibility

### DIFF
--- a/src/components/SearchTextField.tsx
+++ b/src/components/SearchTextField.tsx
@@ -13,7 +13,7 @@ export const SearchTextField = () => {
 
     return (
         <div className="group relative flex w-full flex-1 flex-row items-center">
-            <Search className="pointer-events-none absolute left-3 h-4 w-4 text-sidebar-foreground/60 transition-colors group-focus-within:text-primary" />
+            <Search aria-hidden="true" className="pointer-events-none absolute left-3 h-4 w-4 text-sidebar-foreground/60 transition-colors group-focus-within:text-primary" />
             <Input
                 value={searchQuery ?? undefined}
                 onChange={(event) => {
@@ -28,10 +28,10 @@ export const SearchTextField = () => {
                     onClick={() => {
                         void setSearchQuery("");
                     }}
-                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+                    className="absolute right-3 inline-flex h-5 w-5 items-center justify-center rounded-full text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                     aria-label="Suche zurücksetzen"
                 >
-                    <X className="h-3.5 w-3.5" />
+                    <X aria-hidden="true" className="h-3.5 w-3.5" />
                 </button>
             )}
         </div>


### PR DESCRIPTION
### 💡 What
Added `aria-hidden="true"` attributes to purely decorative icons (Search and X) and introduced explicit keyboard focus ring styles to the clear button in the `SearchTextField` component.

### 🎯 Why
In a Tailwind environment where global outline resets often strip default focus indicators, custom interactive elements need explicit focus styling for keyboard navigation. The decorative icons also previously lacked semantic hiding, causing potential noise for screen reader users when navigating the input/button.

### ♿ Accessibility
- Prevents redundant screen reader announcements for decorative icons by explicitly hiding them from the accessibility tree.
- Ensures the clear search button is visibly highlighted when accessed via keyboard (Tab) navigation, matching standard web accessibility criteria.

---
*PR created automatically by Jules for task [4652859967476404726](https://jules.google.com/task/4652859967476404726) started by @niklasarnitz*