### PR TITLE
🎨 Palette: Add focus states and ARIA attributes to Command Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-04-16 - Add robust aria-labels and decorative icons in `ShowingTimePill`
 **Learning:** Found that time pill links only announced the raw clock time to screen readers (e.g., "14:30") and had no focus styling when navigating via keyboard. Additionally, the decorative `Clock3` icon lacked `aria-hidden="true"`, leading to potential double or messy announcements.
 **Action:** When creating semantic links that rely on visual context (like a time pill underneath a movie title), ensure you build a comprehensive `aria-label` (e.g., "Tickets für [Movie] um [Time] Uhr buchen") and hide decorative icons using `aria-hidden="true"`. Also always verify focus states as global resets can strip them.
+
+## 2024-04-18 - Added Accessibility Enhancements to Command Search
+**Learning:** Found that custom search dropdowns using raw `<button>` elements (instead of pre-styled accessible components like Shadcn's Command menu) often miss focus indicators and screen-reader optimizations. Added standard `focus-visible` ring and `aria-hidden` attributes to these custom interactive elements.
+**Action:** Always verify custom interactive dropdown items for proper `focus-visible` focus styling during keyboard navigation. Purely decorative icons nested inside actionable buttons should receive `aria-hidden="true"`.

--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -116,9 +116,9 @@ export function CommandSearch() {
             <button
                 type="button"
                 onClick={() => setOpen(true)}
-                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border border-input bg-background/60 px-3 text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             >
-                <Search className="h-3.5 w-3.5" />
+                <Search aria-hidden="true" className="h-3.5 w-3.5" />
                 <span className="flex-1 text-left">Suchen…</span>
                 <kbd className="pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex">
                     <span className="text-xs">⌘</span>K
@@ -138,7 +138,7 @@ export function CommandSearch() {
                 <DialogContent className="top-[20%] translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-lg [&>button:last-child]:hidden">
                     <DialogTitle className="sr-only">Suche</DialogTitle>
                     <div className="flex items-center border-b px-3">
-                        <Search className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                        <Search aria-hidden="true" className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
                         <Input
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
@@ -172,9 +172,9 @@ export function CommandSearch() {
                                             onClick={() => navigate(item.href)}
                                             onMouseEnter={() => setActiveIndex(flatIndex)}
                                             data-active={flatIndex === activeIndex}
-                                            className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm data-[active=true]:bg-accent"
+                                            className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm data-[active=true]:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                                         >
-                                            <MapPin className="h-4 w-4 text-muted-foreground" />
+                                            <MapPin aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
                                             {item.name}
                                         </button>
                                     );
@@ -197,9 +197,9 @@ export function CommandSearch() {
                                             onClick={() => navigate(item.href)}
                                             onMouseEnter={() => setActiveIndex(flatIndex)}
                                             data-active={flatIndex === activeIndex}
-                                            className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm data-[active=true]:bg-accent"
+                                            className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm data-[active=true]:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                                         >
-                                            <Building2 className="h-4 w-4 text-muted-foreground" />
+                                            <Building2 aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
                                             <span>{item.name}</span>
                                             <span className="ml-auto text-xs text-muted-foreground">
                                                 {item.subtitle}


### PR DESCRIPTION
💡 **What:** Added `focus-visible` states to the Command Search trigger button and individual search result items. Also added `aria-hidden="true"` to decorative icons.
🎯 **Why:** To make the main search interface more accessible and user-friendly for keyboard navigators and screen-reader users.
♿ **Accessibility:** Users navigating with `Tab` will now see clear focus rings indicating which search result is active. Screen readers will no longer redundantly announce decorative icons (`Search`, `MapPin`, `Building2`) inside the buttons, allowing for a cleaner reading experience.

---
*PR created automatically by Jules for task [13778898948046098005](https://jules.google.com/task/13778898948046098005) started by @niklasarnitz*