### PR TITLE
🧪 Add tests for getBigramSet

### DIFF
--- a/tests/helpers/similarity/getBigramSet.test.ts
+++ b/tests/helpers/similarity/getBigramSet.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, describe } from "bun:test";
+import { getBigramSet } from "@waslaeuftin/helpers/similarity/getBigramSet";
+
+describe("getBigramSet", () => {
+  test("Basic word with more than 2 chars", () => {
+    expect(getBigramSet("hello")).toEqual(new Set(["he", "el", "ll", "lo"]));
+  });
+
+  test("Word with exact 2 characters", () => {
+    expect(getBigramSet("hi")).toEqual(new Set(["hi"]));
+  });
+
+  test("String shorter than 2 characters", () => {
+    expect(getBigramSet("a")).toEqual(new Set(["a"]));
+    expect(getBigramSet("")).toEqual(new Set([""]));
+  });
+
+  test("String with whitespaces", () => {
+    expect(getBigramSet("he llo")).toEqual(new Set(["he", "el", "ll", "lo"]));
+    expect(getBigramSet(" h i ")).toEqual(new Set(["hi"]));
+    expect(getBigramSet("   ")).toEqual(new Set([""]));
+  });
+
+  test("Multiple duplicate bigrams", () => {
+      // "aaaa" -> "aa", "aa", "aa", but set removes duplicates
+      expect(getBigramSet("aaaa")).toEqual(new Set(["aa"]));
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `getBigramSet` function in `src/helpers/similarity/getBigramSet.ts` lacked tests. This testing improvement gap is addressed by adding full unit tests in a new file `tests/helpers/similarity/getBigramSet.test.ts`.

📊 **Coverage:** The new tests cover:
- Standard words of length > 2
- Edge case where word length is exactly 2
- Edge cases where length is < 2 (single char, empty string)
- Correct handling and ignoring of whitespaces
- Correct usage of the Set datastructure removing duplicate bigrams

✨ **Result:** Enhanced the test suite coverage and verified correct behavior of the bigram extraction algorithm without failures.

---
*PR created automatically by Jules for task [18190797334602573543](https://jules.google.com/task/18190797334602573543) started by @niklasarnitz*