### PR TITLE
🧪 Testing: Add tests for getUrlPathJoin

### DIFF
--- a/tests/helpers/titleNormalization/getUrlPathJoin.test.ts
+++ b/tests/helpers/titleNormalization/getUrlPathJoin.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, describe } from "bun:test";
+import { getUrlPathJoin } from "../../../src/helpers/titleNormalization/getUrlPathJoin";
+
+describe("getUrlPathJoin", () => {
+    test("handles empty inputs", () => {
+        expect(getUrlPathJoin()).toBe("");
+        expect(getUrlPathJoin("")).toBe("");
+        expect(getUrlPathJoin("", "")).toBe("");
+    });
+
+    test("joins simple paths without slashes", () => {
+        expect(getUrlPathJoin("foo", "bar")).toBe("foo/bar");
+        expect(getUrlPathJoin("foo", "bar", "baz")).toBe("foo/bar/baz");
+    });
+
+    test("removes redundant leading and trailing slashes", () => {
+        expect(getUrlPathJoin("foo/", "/bar")).toBe("foo/bar");
+        expect(getUrlPathJoin("/foo/", "/bar/")).toBe("/foo/bar");
+        expect(getUrlPathJoin("foo//", "//bar")).toBe("foo/bar");
+        expect(getUrlPathJoin("foo", "//bar", "baz//")).toBe("foo/bar/baz");
+    });
+
+    test("preserves protocol slashes at the start", () => {
+        expect(getUrlPathJoin("http://example.com/", "/foo")).toBe("http://example.com/foo");
+        expect(getUrlPathJoin("https://example.com", "foo/", "/bar")).toBe("https://example.com/foo/bar");
+        expect(getUrlPathJoin("ftp://server.com/", "/path/")).toBe("ftp://server.com/path");
+    });
+
+    test("preserves absolute path at the start", () => {
+        expect(getUrlPathJoin("/api", "/v1/", "/users/")).toBe("/api/v1/users");
+        expect(getUrlPathJoin("/api/", "/v1/", "/users/")).toBe("/api/v1/users");
+    });
+
+    test("filters out empty values in between", () => {
+        expect(getUrlPathJoin("foo", "", "bar")).toBe("foo/bar");
+        expect(getUrlPathJoin("", "foo", "bar")).toBe("foo/bar");
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `getUrlPathJoin` pure function in `src/helpers/titleNormalization/getUrlPathJoin.ts`.
📊 **Coverage:** The new tests cover:
- Empty and falsy inputs
- Simple paths without slashes
- Removal of redundant leading/trailing slashes
- Multiple consecutive slashes
- Preservation of protocol slashes (e.g., `http://`) and absolute paths
✨ **Result:** Increased codebase reliability by guaranteeing correct behavior of the path join helper under various edge cases. The test suite passes 100% locally.

---
*PR created automatically by Jules for task [11184539923679457399](https://jules.google.com/task/11184539923679457399) started by @niklasarnitz*