### PR TITLE
🧪 Testing Improvement: Add missing tests for scoreTmdbCandidate

### DIFF
--- a/tests/helpers/similarity/scoreTmdbCandidate.test.ts
+++ b/tests/helpers/similarity/scoreTmdbCandidate.test.ts
@@ -1,0 +1,87 @@
+import { expect, test, describe } from "bun:test";
+import { scoreTmdbCandidate } from "../../../src/helpers/similarity/scoreTmdbCandidate";
+import { TmdbMovieSearchResult } from "@waslaeuftin/types/TmdbMovieSearchResult";
+
+const createMockResult = (overrides: Partial<TmdbMovieSearchResult> = {}): TmdbMovieSearchResult => ({
+    id: 1,
+    title: "Default Title",
+    original_title: "Default Original Title",
+    original_language: "en",
+    overview: "Default Overview",
+    poster_path: "/poster.jpg",
+    backdrop_path: "/backdrop.jpg",
+    release_date: "2023-01-01",
+    popularity: 100,
+    vote_average: 7.5,
+    vote_count: 1000,
+    adult: false,
+    video: false,
+    genre_ids: [28],
+    ...overrides,
+});
+
+describe("scoreTmdbCandidate", () => {
+    test("returns high score for exact match", () => {
+        const result = createMockResult({
+            title: "The Matrix",
+            original_title: "The Matrix",
+            release_date: "1999-03-31",
+            popularity: 150,
+            poster_path: "/poster.jpg"
+        });
+        const score = scoreTmdbCandidate("the matrix", result);
+        expect(score).toBeGreaterThan(0.9);
+    });
+
+    test("boosts score for original_title match", () => {
+        const result = createMockResult({
+            title: "Die Matrix",
+            original_title: "The Matrix",
+            popularity: 150
+        });
+        const score = scoreTmdbCandidate("the matrix", result);
+        expect(score).toBeGreaterThan(0.9);
+    });
+
+    test("penalizes result without a poster", () => {
+        const unrelatedWithPoster = createMockResult({ title: "Unrelated", original_title: "Unrelated", poster_path: "/poster.jpg", popularity: 0 });
+        const unrelatedWithoutPoster = createMockResult({ title: "Unrelated", original_title: "Unrelated", poster_path: null, popularity: 0 });
+
+        const scoreWith = scoreTmdbCandidate("something else", unrelatedWithPoster);
+        const scoreWithout = scoreTmdbCandidate("something else", unrelatedWithoutPoster);
+
+        expect(scoreWith).toBeGreaterThanOrEqual(scoreWithout);
+    });
+
+    test("poster penalty works as expected before clamping", () => {
+        const resultWithPoster = createMockResult({ title: "The Fast and the Furious", poster_path: "/poster.jpg", popularity: 0 });
+        const resultWithoutPoster = createMockResult({ title: "The Fast and the Furious", poster_path: null, popularity: 0 });
+
+        const scoreWith = scoreTmdbCandidate("fast and furious", resultWithPoster);
+        const scoreWithout = scoreTmdbCandidate("fast and furious", resultWithoutPoster);
+
+        expect(scoreWith - scoreWithout).toBeCloseTo(0.2);
+    });
+
+    test("boosts score for year match", () => {
+        const result = createMockResult({ title: "Inception", release_date: "2010-07-16" });
+        const scoreWithYearMatch = scoreTmdbCandidate("inception 2010", result);
+        const scoreWithoutYearMatch = scoreTmdbCandidate("inception 2011", result);
+
+        expect(scoreWithYearMatch).toBeGreaterThan(scoreWithoutYearMatch);
+    });
+
+    test("boosts score for inclusion", () => {
+        const result = createMockResult({ title: "Star Wars: Episode IV - A New Hope" });
+        const score = scoreTmdbCandidate("star wars", result);
+
+        expect(score).toBeGreaterThan(0.3);
+    });
+
+    test("low score for unrelated movie", () => {
+        const result = createMockResult({ title: "Toy Story" });
+        const score = scoreTmdbCandidate("the godfather", result);
+
+        expect(score).toBeLessThan(0.3);
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for the TMDB candidate scoring helper (`scoreTmdbCandidate`) has been addressed. The function logic is pure but lacked comprehensive test coverage due to the complexity of mocking `TmdbMovieSearchResult` objects.

📊 **Coverage:** A test file `tests/helpers/similarity/scoreTmdbCandidate.test.ts` has been implemented with a `createMockResult` factory to simplify setting up edge cases. The scenarios tested include:
- Exact matches (should result in >0.9 score)
- `original_title` matches (should score equivalent to title match)
- Poster path absence penalty (verifies a ~0.2 drop)
- `release_date` exact match boosting
- String inclusion boosting (when search query matches a substring)
- Unrelated titles (verify scores correctly remain low/zero)

✨ **Result:** Test coverage for `scoreTmdbCandidate` is now significantly improved, ensuring the scoring formula behaves as expected for all defined modifiers and won't regress silently.

---
*PR created automatically by Jules for task [16804733099234747587](https://jules.google.com/task/16804733099234747587) started by @niklasarnitz*