### PR TITLE
🧪 [testing improvement] Add unit tests for ensureMinioFolder

### DIFF
--- a/tests/helpers/fileStorage/ensureMinioFolder.test.ts
+++ b/tests/helpers/fileStorage/ensureMinioFolder.test.ts
@@ -1,0 +1,64 @@
+import { expect, test, describe, mock } from "bun:test";
+import { ensureMinioFolder } from "../../../src/helpers/fileStorage/ensureMinioFolder";
+import { Client as MinioClient } from "minio";
+
+// We need to mock the env so that env.MINIO_BUCKET is available
+mock.module("@waslaeuftin/env", () => ({
+  env: {
+    MINIO_BUCKET: "test-bucket",
+  },
+}));
+
+describe("ensureMinioFolder", () => {
+  test("throws if bucket does not exist", async () => {
+    const mockClient = {
+      bucketExists: mock(() => Promise.resolve(false)),
+    } as unknown as MinioClient;
+
+    await expect(ensureMinioFolder(mockClient, "test-prefix")).rejects.toThrow(
+      'MinIO bucket "test-bucket" does not exist. Please create it first.',
+    );
+  });
+
+  test("does not call putObject if statObject succeeds", async () => {
+    const mockPutObject = mock(() => Promise.resolve());
+    const mockClient = {
+      bucketExists: mock(() => Promise.resolve(true)),
+      statObject: mock(() => Promise.resolve({ size: 100 })),
+      putObject: mockPutObject,
+    } as unknown as MinioClient;
+
+    await ensureMinioFolder(mockClient, "test-prefix");
+    expect(mockClient.bucketExists).toHaveBeenCalledWith("test-bucket");
+    expect(mockClient.statObject).toHaveBeenCalledWith(
+      "test-bucket",
+      "test-prefix/.keep",
+    );
+    expect(mockPutObject).not.toHaveBeenCalled();
+  });
+
+  test("calls putObject if statObject throws", async () => {
+    const mockPutObject = mock(() => Promise.resolve());
+    const mockClient = {
+      bucketExists: mock(() => Promise.resolve(true)),
+      statObject: mock(() => Promise.reject(new Error("Not found"))),
+      putObject: mockPutObject,
+    } as unknown as MinioClient;
+
+    await ensureMinioFolder(mockClient, "test-prefix");
+    expect(mockClient.bucketExists).toHaveBeenCalledWith("test-bucket");
+    expect(mockClient.statObject).toHaveBeenCalledWith(
+      "test-bucket",
+      "test-prefix/.keep",
+    );
+    expect(mockPutObject).toHaveBeenCalledWith(
+      "test-bucket",
+      "test-prefix/.keep",
+      Buffer.from("waslaeuftin movie covers\n"),
+      undefined,
+      {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `ensureMinioFolder` function in `src/helpers/fileStorage/ensureMinioFolder.ts` previously lacked unit tests, specifically missing validation for its error path where `statObject` throws and a subsequent `putObject` fallback is required. This PR introduces a complete unit test suite for the function using `bun:test`.

📊 **Coverage:** The new test file `tests/helpers/fileStorage/ensureMinioFolder.test.ts` fully covers all three execution paths:
1. Throws an error if the minio bucket does not exist.
2. The happy path where `.keep` exists, correctly preventing a redundant `putObject` call.
3. The error path where `statObject` throws (file doesn't exist), successfully triggering the `putObject` fallback.

✨ **Result:** 100% test coverage for the `ensureMinioFolder` function, ensuring it safely handles Minio object creation and preventing regressions in file storage setup.

---
*PR created automatically by Jules for task [10721911239863511300](https://jules.google.com/task/10721911239863511300) started by @niklasarnitz*