### PR TITLE
🔒 Fix JSON-LD Injection XSS Vulnerability

### DIFF
--- a/src/app/cinema/[cinemaSlug]/page.tsx
+++ b/src/app/cinema/[cinemaSlug]/page.tsx
@@ -6,6 +6,7 @@ import { umlautsFixer } from "@waslaeuftin/helpers/umlautsFixer";
 import { api } from "@waslaeuftin/trpc/server";
 import moment from "moment-timezone";
 import { type Metadata } from "next";
+import { safeJsonLd } from "@waslaeuftin/helpers/safeJsonLd";
 
 type CinemaPageProps = {
   params: Promise<{ cinemaSlug?: string }>;
@@ -98,7 +99,7 @@ export default async function CinemaPage({
     <SiteWrapper pathname={pathname} searchParams={decodedParams}>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
       />
       <main className="mx-auto w-full max-w-[1200px]">
         <section className="px-3 py-4 sm:px-4 sm:py-6 md:px-6 md:py-8">

--- a/src/app/city/[citySlug]/page.tsx
+++ b/src/app/city/[citySlug]/page.tsx
@@ -6,6 +6,7 @@ import { type Metadata } from "next";
 import { Constants } from "@waslaeuftin/globals/Constants";
 import { SiteWrapper } from "@waslaeuftin/components/SiteWrapper";
 import { getPathName } from "@waslaeuftin/helpers/getPathName";
+import { safeJsonLd } from "@waslaeuftin/helpers/safeJsonLd";
 
 type MoviesInCityProps = {
   params: Promise<{ citySlug?: string }>;
@@ -88,7 +89,7 @@ export default async function MoviesInCity({
     <SiteWrapper pathname={pathname} searchParams={decodedParams}>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
       />
       <main className="mx-auto w-full max-w-[1200px]">
         <section className="px-3 py-4 sm:px-4 sm:py-6 md:px-6 md:py-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Constants } from "@waslaeuftin/globals/Constants";
 import { SiteWrapper } from "@waslaeuftin/components/SiteWrapper";
 import { getPathName } from "@waslaeuftin/helpers/getPathName";
 import { NearbyCinemasSection } from "@waslaeuftin/components/NearbyCinemasSection";
+import { safeJsonLd } from "@waslaeuftin/helpers/safeJsonLd";
 
 export const dynamic = "force-dynamic";
 
@@ -42,7 +43,7 @@ export default async function Home({
     <SiteWrapper pathname={pathname} searchParams={decodedParams}>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
       />
       <main className="mx-auto w-full max-w-[1200px]">
         <section className="px-3 py-4 sm:px-4 sm:py-6 md:px-6 md:py-8">

--- a/src/helpers/safeJsonLd.ts
+++ b/src/helpers/safeJsonLd.ts
@@ -1,0 +1,8 @@
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}


### PR DESCRIPTION
🎯 **What:** Fixed an XSS vulnerability where `JSON.stringify` was being used to embed `jsonLd` directly into a `<script type="application/ld+json">` tag via `dangerouslySetInnerHTML`.

⚠️ **Risk:** A malicious actor could provide input containing HTML-like strings (such as `</script>`), which when embedded directly, would execute potentially harmful cross-site scripting (XSS) code, jeopardizing user security.

🛡️ **Solution:** Replaced `JSON.stringify` with the `safeJsonLd` utility in `src/app/page.tsx`, `src/app/cinema/[cinemaSlug]/page.tsx`, and `src/app/city/[citySlug]/page.tsx`. This utility safely escapes HTML-sensitive characters (`<`, `>`, `&`) and line terminators into their unicode escape sequence, ensuring the browser parses them strictly as data inside the script tag rather than executable code, while retaining fully functional JSON structure.

---
*PR created automatically by Jules for task [4985353486307332476](https://jules.google.com/task/4985353486307332476) started by @niklasarnitz*