### PR TITLE
🎨 Palette: Improve keyboard focus and screen reader accessibility in CommandSearch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-04-16 - Add robust aria-labels and decorative icons in `ShowingTimePill`
 **Learning:** Found that time pill links only announced the raw clock time to screen readers (e.g., "14:30") and had no focus styling when navigating via keyboard. Additionally, the decorative `Clock3` icon lacked `aria-hidden="true"`, leading to potential double or messy announcements.
 **Action:** When creating semantic links that rely on visual context (like a time pill underneath a movie title), ensure you build a comprehensive `aria-label` (e.g., "Tickets für [Movie] um [Time] Uhr buchen") and hide decorative icons using `aria-hidden="true"`. Also always verify focus states as global resets can strip them.
+
+## 2025-05-24 - Implement ARIA combobox pattern in custom command menus
+**Learning:** Custom command menus (like CommandSearch) often rely entirely on React state (`activeIndex`) and custom keydown listeners (`ArrowDown`/`ArrowUp`) for navigation, while native screen reader announcements lag behind. Additionally, default focus rings on trigger buttons can be stripped by Tailwind resets.
+**Action:** When building custom search dialogs, fully implement the ARIA combobox pattern on the input (`role="combobox"`, `aria-controls`, `aria-activedescendant`) and list (`role="listbox"`, `role="option"`, `aria-selected`). Sync custom arrow-key navigation with native Tab focus by adding `onFocus={() => setActiveIndex(flatIndex)}` to the options, and ensure the trigger button has explicit `focus-visible` styling.

--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -120,11 +120,12 @@ export function CommandSearch() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="border-input bg-background/60 text-muted-foreground hover:bg-accent hover:text-accent-foreground inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border px-3 text-sm shadow-sm transition-colors"
+        aria-haspopup="dialog"
+        className="border-input bg-background/60 text-muted-foreground hover:bg-accent hover:text-accent-foreground inline-flex h-9 w-full max-w-64 items-center gap-2 rounded-lg border px-3 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
       >
         <Search aria-hidden="true" className="h-3.5 w-3.5" />
         <span className="flex-1 text-left">Suchen…</span>
-        <kbd className="bg-muted text-muted-foreground pointer-events-none hidden h-5 items-center gap-0.5 rounded border px-1.5 font-mono text-[10px] font-medium select-none sm:inline-flex">
+        <kbd aria-hidden="true" className="bg-muted text-muted-foreground pointer-events-none hidden h-5 items-center gap-0.5 rounded border px-1.5 font-mono text-[10px] font-medium select-none sm:inline-flex">
           <span className="text-xs">⌘</span>K
         </kbd>
       </button>
@@ -153,11 +154,15 @@ export function CommandSearch() {
               placeholder="Stadt oder Kino suchen…"
               aria-label="Stadt oder Kino suchen"
               className="h-12 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+              role="combobox"
+              aria-expanded={open}
+              aria-controls="cmd-listbox"
+              aria-activedescendant={items.length > 0 ? `cmd-item-${activeIndex}` : undefined}
               autoFocus
             />
           </div>
 
-          <div ref={listRef} className="max-h-72 overflow-y-auto">
+          <div ref={listRef} id="cmd-listbox" role="listbox" aria-label="Suchergebnisse" className="max-h-72 overflow-y-auto">
             {isFetching && (
               <div className="flex items-center justify-center py-6">
                 <Loader2
@@ -187,10 +192,13 @@ export function CommandSearch() {
                       key={item.id}
                       id={`cmd-item-${flatIndex}`}
                       type="button"
+                      role="option"
+                      aria-selected={flatIndex === activeIndex}
                       onClick={() => navigate(item.href)}
                       onMouseEnter={() => setActiveIndex(flatIndex)}
+                      onFocus={() => setActiveIndex(flatIndex)}
                       data-active={flatIndex === activeIndex}
-                      className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm"
+                      className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm focus-visible:outline-none"
                     >
                       <MapPin
                         aria-hidden="true"
@@ -215,10 +223,13 @@ export function CommandSearch() {
                       key={item.id}
                       id={`cmd-item-${flatIndex}`}
                       type="button"
+                      role="option"
+                      aria-selected={flatIndex === activeIndex}
                       onClick={() => navigate(item.href)}
                       onMouseEnter={() => setActiveIndex(flatIndex)}
+                      onFocus={() => setActiveIndex(flatIndex)}
                       data-active={flatIndex === activeIndex}
-                      className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm"
+                      className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm focus-visible:outline-none"
                     >
                       <Building2
                         aria-hidden="true"


### PR DESCRIPTION
💡 What: Implemented the WAI-ARIA combobox pattern in the `CommandSearch` component. Added explicit `focus-visible` styling, combobox attributes to the input (`role`, `aria-controls`, `aria-expanded`, `aria-activedescendant`), listbox roles to the results container, and option roles to the items. Synchronized keyboard navigation state with native browser focus.
🎯 Why: Custom command menus that rely heavily on custom keyboard listeners (`ArrowUp`/`ArrowDown`) and React state frequently lack screen reader support. Native tools need `aria-selected`, `aria-activedescendant`, and explicit roles to properly vocalize the active option. Additionally, standard global resets strip focus indicators, requiring explicit `focus-visible` classes.
♿ Accessibility:
- Added `aria-haspopup="dialog"` to the trigger button.
- Restored focus ring to the trigger button (`focus-visible:ring-2 ...`).
- Hid purely decorative `⌘K` keyboard hint from screen readers.
- Turned the input into an explicit `role="combobox"` that manages a `listbox`.
- Linked virtual `activeIndex` to the DOM via `aria-activedescendant`.
- Kept native `Tab` and custom keyboard navigation in sync via `onFocus` handlers on options.

---
*PR created automatically by Jules for task [13069437541766408526](https://jules.google.com/task/13069437541766408526) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for implementing accessible command/search menu patterns.

* **Bug Fixes**
  * Enhanced search component with improved keyboard navigation and screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->