### PR TITLE
🧹 Fix transaction timeout in movie upserts

### DIFF
--- a/src/helpers/catalogUpdater/resolveAndPersistCatalog.ts
+++ b/src/helpers/catalogUpdater/resolveAndPersistCatalog.ts
@@ -387,34 +387,42 @@ export const resolveAndPersistCatalog = async (
     // This reduces latency by preventing N+1 sequential database roundtrips.
     const movieIdByCanonicalKey = new Map<string, number>();
     const canonicalMoviesList = Array.from(canonicalMovieMap.values());
+    const upsertedMovies: { id: number; canonicalKey: string }[] = [];
+    const BATCH_SIZE_UPSERT = 50;
 
-    const upsertPromises = canonicalMoviesList.map((canonicalMovie) =>
-        db.movie.upsert({
-            where: { canonicalKey: canonicalMovie.canonicalKey },
-            update: {
-                name: canonicalMovie.name,
-                normalizedTitle: canonicalMovie.normalizedTitle,
-                coverUrl: canonicalMovie.coverUrl,
-                coverStorageKey: canonicalMovie.coverStorageKey,
-                coverConfidence: canonicalMovie.coverConfidence,
-                tmdbMovieId: canonicalMovie.tmdbMovieId,
-                tmdbSearchFailedOn: canonicalMovie.tmdbSearchFailedOn,
-            },
-            create: {
-                canonicalKey: canonicalMovie.canonicalKey,
-                name: canonicalMovie.name,
-                normalizedTitle: canonicalMovie.normalizedTitle,
-                coverUrl: canonicalMovie.coverUrl,
-                coverStorageKey: canonicalMovie.coverStorageKey,
-                coverConfidence: canonicalMovie.coverConfidence,
-                tmdbMovieId: canonicalMovie.tmdbMovieId,
-                tmdbSearchFailedOn: canonicalMovie.tmdbSearchFailedOn,
-            },
-            select: { id: true, canonicalKey: true },
-        })
-    );
+    for (let i = 0; i < canonicalMoviesList.length; i += BATCH_SIZE_UPSERT) {
+        const batch = canonicalMoviesList.slice(i, i + BATCH_SIZE_UPSERT);
+        const upsertPromises = batch.map((canonicalMovie) =>
+            db.movie.upsert({
+                where: { canonicalKey: canonicalMovie.canonicalKey },
+                update: {
+                    name: canonicalMovie.name,
+                    normalizedTitle: canonicalMovie.normalizedTitle,
+                    coverUrl: canonicalMovie.coverUrl,
+                    coverStorageKey: canonicalMovie.coverStorageKey,
+                    coverConfidence: canonicalMovie.coverConfidence,
+                    tmdbMovieId: canonicalMovie.tmdbMovieId,
+                    tmdbSearchFailedOn: canonicalMovie.tmdbSearchFailedOn,
+                },
+                create: {
+                    canonicalKey: canonicalMovie.canonicalKey,
+                    name: canonicalMovie.name,
+                    normalizedTitle: canonicalMovie.normalizedTitle,
+                    coverUrl: canonicalMovie.coverUrl,
+                    coverStorageKey: canonicalMovie.coverStorageKey,
+                    coverConfidence: canonicalMovie.coverConfidence,
+                    tmdbMovieId: canonicalMovie.tmdbMovieId,
+                    tmdbSearchFailedOn: canonicalMovie.tmdbSearchFailedOn,
+                },
+                select: { id: true, canonicalKey: true },
+            })
+        );
 
-    const upsertedMovies = await db.$transaction(upsertPromises);
+        const batchResult = await db.$transaction(upsertPromises);
+        for (const movie of batchResult) {
+            upsertedMovies.push(movie);
+        }
+    }
 
     for (const movie of upsertedMovies) {
         movieIdByCanonicalKey.set(movie.canonicalKey, movie.id);


### PR DESCRIPTION
🎯 What: Chunked the large `db.$transaction` execution during movie upserts into batches of 50.
💡 Why: Because Prisma processes an array passed to `db.$transaction` sequentially inside the interactive transaction, passing thousands of operations at once predictably exceeds the default 5000ms limit, throwing a rollback error.
✅ Verification: Ran test suites successfully and deleted test scratchpads.
✨ Result: The nightly action will no longer crash from expired transaction timeouts during bulk movie inserts.

---
*PR created automatically by Jules for task [3782214005558312183](https://jules.google.com/task/3782214005558312183) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized catalog update processing to improve system reliability and performance during bulk data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->