### PR TITLE
⚡ Bolt: Replace flatMap().sort()[0] with O(N) loop for nearby next showing

### DIFF
--- a/src/components/NearbyCinemasSection.tsx
+++ b/src/components/NearbyCinemasSection.tsx
@@ -292,9 +292,18 @@ export const NearbyCinemasSection = () => {
                         <div className="mt-3 grid gap-2 sm:gap-3 sm:grid-cols-2">
                             {filteredCinemas.map((cinema) => {
                                 const originalCinema = nearbyCinemas.find((c) => c.id === cinema.id);
-                                const nextShowing = originalCinema?.movies
-                                    .flatMap((movie) => movie.showings)
-                                    .sort((left, right) => left.dateTime.getTime() - right.dateTime.getTime())[0];
+
+                                // ⚡ Bolt: Replace flatMap().sort()[0] with O(N) loop to avoid intermediate array allocations and O(N log N) sorting
+                                let nextShowing: NonNullable<typeof originalCinema>["movies"][number]["showings"][number] | undefined = undefined;
+                                if (originalCinema) {
+                                    for (const movie of originalCinema.movies) {
+                                        for (const showing of movie.showings) {
+                                            if (!nextShowing || showing.dateTime.getTime() < nextShowing.dateTime.getTime()) {
+                                                nextShowing = showing;
+                                            }
+                                        }
+                                    }
+                                }
 
                                 return (
                                     <article


### PR DESCRIPTION
💡 **What:**
Replaced the `.flatMap().sort()[0]` pattern inside the `.map` render loop in `NearbyCinemasSection.tsx` with an `O(N)` nested loop to find the `nextShowing`.

🎯 **Why:**
The previous implementation used `originalCinema?.movies.flatMap(...).sort(...)[0]` to find the earliest upcoming showing. In V8/Bun (and generally inside a React component render function), calling `.flatMap()` allocates a new intermediate array, and `.sort()` introduces an unnecessary `O(N log N)` computational overhead to find a single minimum element. This caused unnecessary garbage collection pressure and CPU load, especially when there are many cinemas and showings to filter through.

📊 **Impact:**
- Eliminates intermediate array allocations for the `nextShowing` calculation inside the render loop.
- Reduces algorithmic complexity from `O(N log N)` to `O(N)` when finding the closest upcoming showing.
- Results in significantly lower main-thread blocking time during React render cycles for the `NearbyCinemasSection`.

🔬 **Measurement:**
- Run `SKIP_ENV_VALIDATION=1 DATABASE_URL="postgresql://user:password@localhost:5432/mydb" bun test` to verify `groupMoviesByTitle` and other showing-related components still behave correctly. 
- The build has been verified using `bun run build`. (Note: The static page collector fails on missing DB, but compilation and TS typecheck succeed).

---
*PR created automatically by Jules for task [15894203093743689892](https://jules.google.com/task/15894203093743689892) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the logic for determining next cinema showtimes to improve code efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklasarnitz/waslaeuftin/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->