### PR TITLE
🎨 Palette: Improve screen reader support for command search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-04-16 - Add robust aria-labels and decorative icons in `ShowingTimePill`
 **Learning:** Found that time pill links only announced the raw clock time to screen readers (e.g., "14:30") and had no focus styling when navigating via keyboard. Additionally, the decorative `Clock3` icon lacked `aria-hidden="true"`, leading to potential double or messy announcements.
 **Action:** When creating semantic links that rely on visual context (like a time pill underneath a movie title), ensure you build a comprehensive `aria-label` (e.g., "Tickets für [Movie] um [Time] Uhr buchen") and hide decorative icons using `aria-hidden="true"`. Also always verify focus states as global resets can strip them.
+
+## 2025-05-17 - Add WAI-ARIA combobox pattern for custom search dialogs
+**Learning:** Found that the Command Search dialog used standard buttons for results, lacking semantic meaning for screen readers inside an interactive search list. While standard inputs provide focus behavior, complex interactions like ArrowKey navigation over search results need explicit active descendant tracking for screen readers to announce options synchronously with visual state.
+**Action:** When implementing custom search dialogs/autocomplete, fully utilize the WAI-ARIA combobox pattern (`role="combobox"`, `aria-controls`, `aria-activedescendant` on the input; `role="listbox"`, `role="option"`, `aria-selected` on the results). Ensure to sync custom arrow-key state with native Tab navigation by attaching `onFocus` handlers.

--- a/src/components/CommandSearch.tsx
+++ b/src/components/CommandSearch.tsx
@@ -154,10 +154,21 @@ export function CommandSearch() {
               aria-label="Stadt oder Kino suchen"
               className="h-12 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
               autoFocus
+              role="combobox"
+              aria-expanded={open}
+              aria-controls="cmd-list"
+              aria-activedescendant={
+                items.length > 0 ? `cmd-item-${activeIndex}` : undefined
+              }
             />
           </div>
 
-          <div ref={listRef} className="max-h-72 overflow-y-auto">
+          <div
+            ref={listRef}
+            id="cmd-list"
+            role="listbox"
+            className="max-h-72 overflow-y-auto"
+          >
             {isFetching && (
               <div className="flex items-center justify-center py-6">
                 <Loader2
@@ -186,9 +197,12 @@ export function CommandSearch() {
                     <button
                       key={item.id}
                       id={`cmd-item-${flatIndex}`}
+                      role="option"
+                      aria-selected={flatIndex === activeIndex}
                       type="button"
                       onClick={() => navigate(item.href)}
                       onMouseEnter={() => setActiveIndex(flatIndex)}
+                      onFocus={() => setActiveIndex(flatIndex)}
                       data-active={flatIndex === activeIndex}
                       className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm"
                     >
@@ -214,9 +228,12 @@ export function CommandSearch() {
                     <button
                       key={item.id}
                       id={`cmd-item-${flatIndex}`}
+                      role="option"
+                      aria-selected={flatIndex === activeIndex}
                       type="button"
                       onClick={() => navigate(item.href)}
                       onMouseEnter={() => setActiveIndex(flatIndex)}
+                      onFocus={() => setActiveIndex(flatIndex)}
                       data-active={flatIndex === activeIndex}
                       className="data-[active=true]:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm"
                     >


### PR DESCRIPTION
💡 What: Implemented the WAI-ARIA combobox pattern for the `CommandSearch` component. Added appropriate ARIA roles and attributes to the input field, the listbox container, and individual options. Also synchronized explicit native focus events with custom arrow-key state.
🎯 Why: Standard `<button>` elements in a custom dropdown search are not adequately described to screen readers. This change ensures screen readers properly understand that this is an autocomplete combobox, hear the available options when navigating, and announce the currently focused item synchronously.
📸 Before/After: Visuals remain unchanged, but the DOM now correctly models the combobox state.
♿ Accessibility: Fully resolves missing combobox pattern attributes (`role="combobox"`, `role="listbox"`, `role="option"`, `aria-activedescendant`, `aria-selected`, `aria-expanded`) ensuring WCAG 2.1 compliance for custom search dialogs.

---
*PR created automatically by Jules for task [16098339093247499875](https://jules.google.com/task/16098339093247499875) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for the command search dialog with improved keyboard navigation and comprehensive screen reader support. The search input now provides clearer feedback regarding its expanded state and available options. Keyboard focus management has been refined to support both arrow-key navigation and Tab navigation, enabling more intuitive interaction with search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklasarnitz/waslaeuftin/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->