### PR TITLE
🧹 Remove console.log in getKinoHeldCinemas

### DIFF
--- a/src/cinemaProviders/kinoheld/getKinoHeldCinemas.ts
+++ b/src/cinemaProviders/kinoheld/getKinoHeldCinemas.ts
@@ -30,10 +30,6 @@ async function getKinoHeldCinemasInner(
     throw new Error("Could not load KinoHeld cinemas");
   }
 
-  console.log(
-    "Currently at page " + page + " of " + data.cinemas.paginatorInfo.lastPage,
-  );
-
   const newData = allData.concat(data.cinemas.data);
   if (data.cinemas.paginatorInfo.hasMorePages) {
     return await getKinoHeldCinemasInner(page + 1, newData);


### PR DESCRIPTION
🎯 **What:**
Removed a debugging `console.log` statement from `src/cinemaProviders/kinoheld/getKinoHeldCinemas.ts` that was logging the current page and total pages being fetched from the KinoHeld GraphQL API.

💡 **Why:**
Leaving `console.log` statements in production code, especially in data fetching logic, causes unnecessary noise and clutter in server logs. Removing this improves code health, maintainability, and log readability without changing any functional behavior of the integration.

✅ **Verification:**
1. Manually verified the `replace_with_git_merge_diff` change with `cat`.
2. Ran the unit test suite with `bun test` in a local environment (with `SKIP_ENV_VALIDATION=1 DATABASE_URL="..."`) to ensure no regressions were introduced.
3. Passed code review.

✨ **Result:**
The API fetching for KinoHeld cinemas is cleaner, quieter, and no longer spams standard output with page tracking debug information during execution.

---
*PR created automatically by Jules for task [9847840249697514225](https://jules.google.com/task/9847840249697514225) started by @niklasarnitz*