### PR TITLE
🧪 Testing Improvement: Add tests for normalizePrefix

### DIFF
--- a/tests/helpers/titleNormalization/normalizePrefix.test.ts
+++ b/tests/helpers/titleNormalization/normalizePrefix.test.ts
@@ -1,0 +1,39 @@
+import { expect, test, describe } from "bun:test";
+import { normalizePrefix } from "../../../src/helpers/titleNormalization/normalizePrefix";
+
+describe("normalizePrefix", () => {
+    test("removes leading slashes", () => {
+        expect(normalizePrefix("/foo")).toBe("foo");
+        expect(normalizePrefix("//foo")).toBe("foo");
+    });
+
+    test("removes trailing slashes", () => {
+        expect(normalizePrefix("foo/")).toBe("foo");
+        expect(normalizePrefix("foo//")).toBe("foo");
+    });
+
+    test("removes both leading and trailing slashes", () => {
+        expect(normalizePrefix("/foo/")).toBe("foo");
+        expect(normalizePrefix("//foo//")).toBe("foo");
+    });
+
+    test("handles strings without slashes", () => {
+        expect(normalizePrefix("foo")).toBe("foo");
+    });
+
+    test("handles empty strings", () => {
+        expect(normalizePrefix("")).toBe("");
+    });
+
+    test("handles strings containing only slashes", () => {
+        expect(normalizePrefix("/")).toBe("");
+        expect(normalizePrefix("//")).toBe("");
+        expect(normalizePrefix("///")).toBe("");
+    });
+
+    test("preserves slashes in the middle of the string", () => {
+        expect(normalizePrefix("foo/bar")).toBe("foo/bar");
+        expect(normalizePrefix("/foo/bar/")).toBe("foo/bar");
+        expect(normalizePrefix("//foo//bar//")).toBe("foo//bar");
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `normalizePrefix` helper function.
📊 **Coverage:** Covered scenarios including removing leading slashes, trailing slashes, both leading and trailing slashes, handling strings without slashes, empty strings, and strings containing only slashes, while preserving slashes in the middle.
✨ **Result:** Improved test coverage and reliability for title normalization helpers.

---
*PR created automatically by Jules for task [17755725204869923114](https://jules.google.com/task/17755725204869923114) started by @niklasarnitz*