### PR TITLE
🔒 Fix IP spoofing via x-forwarded-for header

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -32,6 +32,7 @@ export const env = createEnv({
         MINIO_PUBLIC_BASE_URL: z.string().url(),
         UMAMI_URL: z.url(),
         UMAMI_WEBSITE_ID: z.string(),
+        TRUSTED_PROXIES_COUNT: z.coerce.number().min(0).default(1),
     },
     client: {},
     runtimeEnv: {
@@ -51,7 +52,8 @@ export const env = createEnv({
         MINIO_MOVIE_COVERS_PREFIX: process.env.MINIO_MOVIE_COVERS_PREFIX,
         MINIO_PUBLIC_BASE_URL: process.env.MINIO_PUBLIC_BASE_URL,
         UMAMI_URL: process.env.UMAMI_URL,
-        UMAMI_WEBSITE_ID: process.env.UMAMI_WEBSITE_ID
+        UMAMI_WEBSITE_ID: process.env.UMAMI_WEBSITE_ID,
+        TRUSTED_PROXIES_COUNT: process.env.TRUSTED_PROXIES_COUNT
     },
     skipValidation: !!process.env.SKIP_ENV_VALIDATION,
     emptyStringAsUndefined: true,

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -10,6 +10,7 @@ import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
+import { env } from "@waslaeuftin/env";
 import { db } from "@waslaeuftin/server/db";
 
 /**
@@ -25,10 +26,20 @@ import { db } from "@waslaeuftin/server/db";
  * @see https://trpc.io/docs/server/context
  */
 export const getClientIp = (headers: Headers): string | undefined => {
+  if (env.TRUSTED_PROXIES_COUNT === 0) {
+    return undefined;
+  }
+
   const forwarded = headers.get("x-forwarded-for");
   if (forwarded) {
-    const first = forwarded.split(",")[0]?.trim();
-    if (first && first !== "unknown") return first;
+    const ips = forwarded
+      .split(",")
+      .map((ip) => ip.trim())
+      .filter((ip) => ip && ip !== "unknown");
+    if (ips.length > 0) {
+      const index = Math.max(0, ips.length - env.TRUSTED_PROXIES_COUNT);
+      return ips[index];
+    }
   }
 
   const realIp = headers.get("x-real-ip")?.trim();

--- a/tests/server/api/trpc.test.ts
+++ b/tests/server/api/trpc.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("@waslaeuftin/env", () => ({
+  env: { TRUSTED_PROXIES_COUNT: 1 },
+}));
+
+import { getClientIp } from "../../../src/server/api/trpc";
+import { env } from "@waslaeuftin/env";
+
+describe("getClientIp", () => {
+  it("returns correct ip behind 1 proxy", () => {
+    env.TRUSTED_PROXIES_COUNT = 1;
+    const headers = new Headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" });
+    expect(getClientIp(headers)).toBe("5.6.7.8");
+  });
+  it("returns correct ip behind 2 proxies", () => {
+    env.TRUSTED_PROXIES_COUNT = 2;
+    const headers = new Headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8, 9.10.11.12" });
+    expect(getClientIp(headers)).toBe("5.6.7.8");
+  });
+  it("returns undefined if 0 trusted proxies", () => {
+    env.TRUSTED_PROXIES_COUNT = 0;
+    const headers = new Headers({ "x-forwarded-for": "1.2.3.4" });
+    expect(getClientIp(headers)).toBeUndefined();
+  });
+  it("returns real-ip if x-forwarded-for is absent", () => {
+    env.TRUSTED_PROXIES_COUNT = 1;
+    const headers = new Headers({ "x-real-ip": "1.2.3.4" });
+    expect(getClientIp(headers)).toBe("1.2.3.4");
+  });
+});


### PR DESCRIPTION
🎯 **What:**
The `getClientIp` function previously blindly trusted the first (left-most) IP address in the `x-forwarded-for` header, allowing users to inject forged IP addresses into the request.

⚠️ **Risk:**
Attackers could easily spoof their IP address by sending requests with custom `X-Forwarded-For` headers. This undermines any IP-based analytics, rate limiting, logging, and view deduplication systems (such as Umami tracking).

🛡️ **Solution:**
Added a new environment variable `TRUSTED_PROXIES_COUNT` (default: 1) which indicates the number of reverse proxies sitting between the internet and the application. The `getClientIp` logic has been updated to count backwards from the right side of the `x-forwarded-for` list, securely extracting the IP address appended by the outermost trusted proxy and discarding any potentially injected IPs on the left side. If `TRUSTED_PROXIES_COUNT` is set to 0, it falls back to ignoring proxy headers completely. Also added full unit tests verifying the behavior.

---
*PR created automatically by Jules for task [6808292955832274213](https://jules.google.com/task/6808292955832274213) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `TRUSTED_PROXIES_COUNT` configuration option (default: 1) to control client IP address extraction when behind trusted proxies.

* **Bug Fixes**
  * Improved IP extraction logic to correctly identify client addresses based on the number of trusted proxies in your environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->