### PR TITLE
⚡ Bolt: O(1) index calculation for CommandSearch items

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-27 - O(N^2) Bottleneck in React Render Loops via indexOf
+**Learning:** In React render loops, computing indices using `.indexOf()` on concatenated arrays creates an O(N^2) bottleneck. When looping through partitions of an array (e.g., `.filter(typeA)` followed by `.filter(typeB)`), finding the flat index from the original array is slow.
+**Action:** Always compute the flat index in O(1) time directly using the map's current index and the length of the preceding arrays (e.g., `flatIndex = prevArray.length + index`), completely eliminating the overhead of `.indexOf()` calls within render cycles.

--- a/apps/nextjs/src/components/CommandSearch.tsx
+++ b/apps/nextjs/src/components/CommandSearch.tsx
@@ -195,8 +195,9 @@ export function CommandSearch() {
                 <p className="text-muted-foreground px-3 pb-1.5 text-xs font-medium">
                   {query.length > 0 ? "Städte" : "Städte in der Nähe"}
                 </p>
-                {cityItems.map((item) => {
-                  const flatIndex = items.indexOf(item);
+                {cityItems.map((item, index) => {
+                  // ⚡ Bolt Optimization: O(1) index calculation instead of O(N) items.indexOf(item)
+                  const flatIndex = index;
                   return (
                     <button
                       key={item.id}
@@ -227,8 +228,9 @@ export function CommandSearch() {
                 <p className="text-muted-foreground px-3 pb-1.5 text-xs font-medium">
                   {query.length > 0 ? "Kinos" : "Kinos in der Nähe"}
                 </p>
-                {cinemaItems.map((item) => {
-                  const flatIndex = items.indexOf(item);
+                {cinemaItems.map((item, index) => {
+                  // ⚡ Bolt Optimization: O(1) index calculation instead of O(N) items.indexOf(item)
+                  const flatIndex = cityItems.length + index;
                   return (
                     <button
                       key={item.id}


### PR DESCRIPTION
💡 What: Replaced `items.indexOf(item)` with direct O(1) index calculation in `CommandSearch.tsx` map loops.
🎯 Why: Calling `.indexOf()` inside a `.map()` on a concatenated array created an unnecessary O(N^2) bottleneck during render.
📊 Measured Improvement: Reduces time complexity of rendering the result list from O(N^2) to O(N).
🔬 Measurement: Verify by searching a large list of cities/cinemas; rendering is now O(1) per item.

---
*PR created automatically by Jules for task [955471786514015750](https://jules.google.com/task/955471786514015750) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command search rendering performance, making result lists feel more responsive.
  * Kept keyboard navigation and item selection consistent while updating how result positions are tracked.

* **Documentation**
  * Added a note about a rendering performance pattern and a faster way to calculate item positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->