### PR TITLE
Add movie detail page when tapping an upcoming movie

### DIFF
--- a/apps/expo/src/app/(upcoming)/_layout.tsx
+++ b/apps/expo/src/app/(upcoming)/_layout.tsx
@@ -26,6 +26,10 @@ export default function UpcomingLayout() {
         name="movie/[movieName]"
         options={{ title: "", headerLargeTitle: false }}
       />
+      <Stack.Screen
+        name="details/[tmdbMovieId]"
+        options={{ title: "", headerLargeTitle: false }}
+      />
     </Stack>
   );
 }

--- a/apps/expo/src/app/(upcoming)/details/[tmdbMovieId].tsx
+++ b/apps/expo/src/app/(upcoming)/details/[tmdbMovieId].tsx
@@ -3,8 +3,8 @@ import { Pressable, ScrollView, Text, View } from "react-native";
 import { useLocalSearchParams, useNavigation } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 
-import { MoviePoster } from "@waslaeuftin/expo/components/movie-poster";
 import type { UpcomingMovieCardData } from "@waslaeuftin/expo/components/upcoming-movie-card";
+import { MoviePoster } from "@waslaeuftin/expo/components/movie-poster";
 import { formatReleaseDate } from "@waslaeuftin/expo/components/upcoming-movie-card";
 import { useTrackMobileScreen } from "@waslaeuftin/expo/utils/analytics";
 import { usePrimaryColor } from "@waslaeuftin/expo/utils/theme";

--- a/apps/expo/src/app/(upcoming)/details/[tmdbMovieId].tsx
+++ b/apps/expo/src/app/(upcoming)/details/[tmdbMovieId].tsx
@@ -1,0 +1,135 @@
+import React, { useEffect } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { useLocalSearchParams, useNavigation } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+
+import { MoviePoster } from "@waslaeuftin/expo/components/movie-poster";
+import type { UpcomingMovieCardData } from "@waslaeuftin/expo/components/upcoming-movie-card";
+import { formatReleaseDate } from "@waslaeuftin/expo/components/upcoming-movie-card";
+import { useTrackMobileScreen } from "@waslaeuftin/expo/utils/analytics";
+import { usePrimaryColor } from "@waslaeuftin/expo/utils/theme";
+import { useReminders } from "@waslaeuftin/expo/utils/use-reminders";
+
+interface UpcomingMovieDetailData extends UpcomingMovieCardData {
+  posterPath: string | null;
+}
+
+function getFirstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseMovieParam(movieParam: string | string[] | undefined) {
+  const rawMovie = getFirstParam(movieParam);
+  if (!rawMovie) return null;
+
+  try {
+    return JSON.parse(rawMovie) as UpcomingMovieDetailData;
+  } catch (err) {
+    console.error("Failed to parse upcoming movie detail params", err);
+    return null;
+  }
+}
+
+export default function UpcomingMovieDetailScreen() {
+  const navigation = useNavigation();
+  const primaryColor = usePrimaryColor();
+  useTrackMobileScreen("movie");
+  const params = useLocalSearchParams<{
+    movie?: string | string[];
+    tmdbMovieId?: string | string[];
+  }>();
+  const movie = React.useMemo(
+    () => parseMovieParam(params.movie),
+    [params.movie],
+  );
+  const { isReminded, toggle } = useReminders();
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: movie?.title ?? "Film",
+      headerLargeTitle: false,
+    });
+  }, [movie?.title, navigation]);
+
+  if (!movie) {
+    return (
+      <View className="bg-background flex-1 items-center justify-center p-6">
+        <Text className="text-foreground text-base font-semibold">
+          Film konnte nicht geöffnet werden
+        </Text>
+        <Text className="text-muted-foreground mt-1 text-center text-xs">
+          Öffne den Film bitte erneut aus der Liste.
+        </Text>
+      </View>
+    );
+  }
+
+  const releaseLabel = formatReleaseDate(movie.releaseDate);
+  const reminded = isReminded(movie.tmdbMovieId);
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      className="bg-background flex-1"
+      contentContainerStyle={{ padding: 16, gap: 16 }}
+    >
+      <View
+        className="bg-card border-border/40 gap-4 rounded-2xl border p-4 shadow-sm"
+        style={{ borderCurve: "continuous" }}
+      >
+        <View className="flex-row gap-4">
+          <MoviePoster coverUrl={movie.posterUrl} size="lg" />
+          <View className="min-w-0 flex-1 gap-2">
+            <Text className="text-foreground text-2xl leading-tight font-bold tracking-tight">
+              {movie.title}
+            </Text>
+            {releaseLabel ? (
+              <Text className="text-muted-foreground text-xs font-medium">
+                Kinostart: {releaseLabel}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        <View className="bg-border/40 h-[1px]" />
+
+        <Pressable
+          onPress={() =>
+            toggle({
+              tmdbMovieId: movie.tmdbMovieId,
+              title: movie.title,
+              posterPath: movie.posterPath,
+            })
+          }
+          className={`flex-row items-center gap-1.5 self-start rounded-lg px-3 py-1.5 ${
+            reminded ? "bg-primary" : "bg-primary/10"
+          }`}
+        >
+          <Ionicons
+            name={reminded ? "notifications" : "notifications-outline"}
+            size={14}
+            color={reminded ? "#fff" : primaryColor}
+          />
+          <Text
+            className={`text-xs font-bold ${
+              reminded ? "text-white" : "text-primary"
+            }`}
+          >
+            {reminded ? "Erinnerung aktiv" : "Erinnern"}
+          </Text>
+        </Pressable>
+
+        {movie.overview ? (
+          <View className="gap-1">
+            <Text className="text-foreground text-sm font-bold tracking-tight">
+              Beschreibung
+            </Text>
+            <Text className="text-muted-foreground text-sm leading-relaxed">
+              {movie.overview}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/expo/src/app/(upcoming)/index.tsx
+++ b/apps/expo/src/app/(upcoming)/index.tsx
@@ -7,6 +7,7 @@ import {
   View,
 } from "react-native";
 import * as Location from "expo-location";
+import { useRouter } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { UpcomingMovieCard } from "@waslaeuftin/expo/components/upcoming-movie-card";
@@ -18,6 +19,7 @@ import { usePrimaryColor } from "@waslaeuftin/expo/utils/theme";
 import { useReminders } from "@waslaeuftin/expo/utils/use-reminders";
 
 export default function UpcomingScreen() {
+  const router = useRouter();
   const primaryColor = usePrimaryColor();
   const { refreshing, onRefresh } = useRefresh();
   useTrackMobileScreen("upcoming");
@@ -78,6 +80,22 @@ export default function UpcomingScreen() {
               tmdbMovieId: item.tmdbMovieId,
               title: item.title,
               posterPath: item.posterPath,
+            })
+          }
+          onPress={() =>
+            router.push({
+              pathname: "/details/[tmdbMovieId]",
+              params: {
+                tmdbMovieId: String(item.tmdbMovieId),
+                movie: JSON.stringify({
+                  tmdbMovieId: item.tmdbMovieId,
+                  title: item.title,
+                  posterUrl: item.posterUrl,
+                  posterPath: item.posterPath,
+                  releaseDate: item.releaseDate,
+                  overview: item.overview,
+                }),
+              },
             })
           }
         />

--- a/apps/expo/src/components/upcoming-movie-card.tsx
+++ b/apps/expo/src/components/upcoming-movie-card.tsx
@@ -19,7 +19,7 @@ interface UpcomingMovieCardProps {
   onPress?: () => void;
 }
 
-const formatReleaseDate = (releaseDate: string | null) => {
+export const formatReleaseDate = (releaseDate: string | null) => {
   if (!releaseDate) return null;
   const date = new Date(releaseDate);
   if (Number.isNaN(date.getTime())) return null;


### PR DESCRIPTION
Tapping an upcoming movie card now opens a detail screen with the
poster, release date, full overview, and reminder toggle, using the
data already fetched for the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated detail screens for upcoming films.
  * Upcoming film cards now open a detail view with poster, title, release date, overview, and reminder controls.
  * Users can add or remove reminders directly from the film detail screen.
  * Added navigation support for opening upcoming film details from the list.

* **Bug Fixes**
  * Added fallback messaging when film details cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->