### PR TITLE
⚡ Bolt: Optimize CommandSearch by replacing O(N^2) indexOf with O(1) calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [React Render Loop O(N^2) Optimization]
+**Learning:** In React render loops, using `Array.indexOf()` within a `.map()` over concatenated arrays creates an O(N^2) bottleneck. The memory states that we should calculate the flat index directly from the map's index and the preceding array's length.
+**Action:** Replace `indexOf` in `.map()` with O(1) mathematical index calculation when mapping over subset arrays.

--- a/apps/nextjs/src/components/CommandSearch.tsx
+++ b/apps/nextjs/src/components/CommandSearch.tsx
@@ -195,8 +195,9 @@ export function CommandSearch() {
                 <p className="text-muted-foreground px-3 pb-1.5 text-xs font-medium">
                   {query.length > 0 ? "Städte" : "Städte in der Nähe"}
                 </p>
-                {cityItems.map((item) => {
-                  const flatIndex = items.indexOf(item);
+                {cityItems.map((item, index) => {
+                  // O(1) index calculation instead of O(N) items.indexOf(item) in render loop
+                  const flatIndex = index;
                   return (
                     <button
                       key={item.id}
@@ -227,8 +228,9 @@ export function CommandSearch() {
                 <p className="text-muted-foreground px-3 pb-1.5 text-xs font-medium">
                   {query.length > 0 ? "Kinos" : "Kinos in der Nähe"}
                 </p>
-                {cinemaItems.map((item) => {
-                  const flatIndex = items.indexOf(item);
+                {cinemaItems.map((item, index) => {
+                  // O(1) index calculation instead of O(N) items.indexOf(item) in render loop
+                  const flatIndex = cityItems.length + index;
                   return (
                     <button
                       key={item.id}


### PR DESCRIPTION
💡 What: Removed `items.indexOf(item)` calls within the `.map()` loops in the CommandSearch component.
🎯 Why: `indexOf` searches an array linearly, making the time complexity O(N^2) when used inside a loop over the same array elements. The flat index can instead be derived using O(1) mathematical index calculation from the loop `index` and offset arrays.
📊 Impact: Considerably faster render loops when populating UI results in the CommandSearch dialog.
🔬 Measurement: Verify by rendering large sets of search results using the Command Search and observe UI rendering time with browser performance profiler.

Recorded critical learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10864651175525614781](https://jules.google.com/task/10864651175525614781) started by @niklasarnitz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved search result rendering efficiency, especially for city and cinema results.
  * Preserved existing keyboard navigation and item selection behavior while reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->